### PR TITLE
Restructured Command Protocol and Misc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    commonjs: true,
+    es6: true,
+    node: true
+  },
+  extends: [
+    'standard'
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly'
+  },
+  parserOptions: {
+    ecmaVersion: 2018
+  },
+  rules: {
+    "indent": ["error", 2]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Lancelot
-Discord Bot generated with [create-discord-bot](https://github.com/HZooly/create-discord-bot)
+Discord bot created to serve the KnightHacks discord. Feel free to join us here [Here!](https://discord.gg/C4cuHFS) 
+
+## Setup
+//TODO
+
+## Config.json
+* token
+* prefix
+* mute_role

--- a/bot.js
+++ b/bot.js
@@ -1,10 +1,10 @@
 const Discord = require('discord.js')
-const {token} = require('./config.json')
+const { token } = require('./config.json')
 const client = new Discord.Client()
 const commandHandler = require('./commands/command-handler')
 
 client.on('ready', () => {
-  console.log('Bot is ready!');
+  console.log('Bot is ready!')
 })
 
 client.on('message', async message => commandHandler(message))

--- a/bot.js
+++ b/bot.js
@@ -1,86 +1,12 @@
-const Discord = require('discord.js');
-const { prefix, token } = require('./config.json');
-const client = new Discord.Client();
-
-// const guild = client.guilds.get('592518485305982996');
+const Discord = require('discord.js')
+const {token} = require('./config.json')
+const client = new Discord.Client()
+const commandHandler = require('./commands/command-handler')
 
 client.on('ready', () => {
   console.log('Bot is ready!');
-});
+})
 
-client.on('message', async message => {
-  if (message.author.bot) return;
-  if (message.channel.type === 'dm') return;
+client.on('message', async message => commandHandler(message))
 
-  // cmd = The command itself
-  // Args = rest of the line
-  const line = message.content.split(' ');
-  const cmd = line[0];
-  let args = line.slice(1);
-  const guild = message.guild;
-  if (cmd === `${prefix}ping`) {
-    await message.channel.send('Pong.');
-  }
-
-  // Show amount of people online
-  if (cmd === `${prefix}stats`) {
-    let online = guild.members.filter(m => m.presence.status === 'online');
-    let admins = online.filter(m => m.roles.has('619209554261049345'));
-    let dnd = guild.members.filter(m => m.presence.status === 'do not disturb');
-    let idle = guild.members.filter(m => m.presence.status === 'idle');
-
-    let embed = new Discord.RichEmbed()
-      .setDescription('Information')
-      .setColor('#15f153')
-      .setThumbnail(guild.iconURL)
-      .addField('Server Name', guild.name)
-      .addField('Created On', guild.createdAt)
-      .addField('Total Members', guild.memberCount)
-      .addField('Online', online.size)
-      .addField('Do Not Disturb', dnd.size)
-      .addField('Idle', idle.size)
-      .addField('Admins available', admins.size);
-
-    await message.channel.send(embed);
-  }
-
-  // Kick/ban a user
-  if (cmd === `${prefix}kick` || cmd === `${prefix}ban`) {
-    if (message.member.hasPermission('MANAGE_MESSAGES')) {
-      let yeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-      if (yeet) {
-        if (cmd === `${prefix}kick`) await guild.kick(yeet).catch(console.error);
-        else await guild.ban(yeet).catch(console.error);
-      }
-    }
-  }
-
-  // Mutes a user
-  if (cmd === `${prefix}mute`) {
-    if (message.member.hasPermission('MANAGE_MESSAGES')) {
-      let yeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-      if (yeet && yeet.id !== message.author.id && toMute.highestRole.position < message.member.highestRole.position)
-        await yeet.addRole('SADB MUTED');
-    }
-  }
-
-  // Unmutes a user
-  if (cmd === `${prefix}unmute`) {
-    if (message.member.hasPermission('MANAGE_MESSAGES')) {
-      let unYeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-      if (unYeet) await unYeet.removeRole('SADB MUTED');
-    }
-  }
-
-  // Remove n messages from a channel
-  if (cmd === `${prefix}purge`) {
-    const num = parseInt(args[0], 10);
-
-    if (num) {
-      const fetchMsg = await msg.channel.fetchMessages({ limit: num });
-      await message.channel.bulkDelete(fetchMsg).catch(e => message.reply(`Couldn't delete messages because of: ${e}`));
-    }
-  }
-});
-
-client.login(token);
+client.login(token)

--- a/bot.js
+++ b/bot.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const { prefix, token } = require('./config.json');
 const client = new Discord.Client();
 
-const guild = client.guilds.get('592518485305982996');
+// const guild = client.guilds.get('592518485305982996');
 
 client.on('ready', () => {
   console.log('Bot is ready!');
@@ -17,7 +17,7 @@ client.on('message', async message => {
   const line = message.content.split(' ');
   const cmd = line[0];
   let args = line.slice(1);
-
+  const guild = message.guild;
   if (cmd === `${prefix}ping`) {
     await message.channel.send('Pong.');
   }
@@ -41,7 +41,7 @@ client.on('message', async message => {
       .addField('Idle', idle.size)
       .addField('Admins available', admins.size);
 
-    await msg.channel.send(embed);
+    await message.channel.send(embed);
   }
 
   // Kick/ban a user

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,0 +1,9 @@
+module.exports = async function(command){
+    if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
+        const {message, args} = command; 
+        let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
+        
+        await member.ban(member).catch(console.error);
+        //add message whenever someone gets banned to a logging channel
+    }
+}

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,9 +1,9 @@
-module.exports = async function(command){
-    if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
-        const {message, args} = command; 
-        let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-        
-        await member.ban(member).catch(console.error);
-        //add message whenever someone gets banned to a logging channel
-    }
+module.exports = async function (command) {
+  if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
+    const { message, args } = command
+    const member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0])
+
+    await member.ban(member).catch(console.error)
+    // add message whenever someone gets banned to a logging channel
+  }
 }

--- a/commands/command-handler.js
+++ b/commands/command-handler.js
@@ -1,0 +1,19 @@
+const commandMap = require("");
+module.exports = function(message, prefix){
+    if (message.author.bot) return;
+    if (message.channel.type === 'dm') return;
+    
+    const line = message.content.split(' ');
+    let command = {
+        "name": line[0],
+        "args": line.slice(1),
+        "message": message,
+    };
+    
+    if( command.name.substring(0,1) != prefix ) return;
+    if ( commandMap[command.name] == null ) return;
+    
+    commandMap[command.name](command);
+    
+
+}

--- a/commands/command-handler.js
+++ b/commands/command-handler.js
@@ -1,18 +1,20 @@
-const commandMap = require("");
-module.exports = function(message, prefix){
+const commandMap = require('./command-map');
+const {prefix} = require('../config'); 
+module.exports = async function(message){
     if (message.author.bot) return;
     if (message.channel.type === 'dm') return;
     
     const line = message.content.split(' ');
     let command = {
-        "name": line[0],
+        "name": line[0].substring(1).toLowerCase(),
+        "prefix": line[0].substring(0,1),
         "args": line.slice(1),
         "message": message,
     };
     
-    if( command.name.substring(0,1) != prefix ) return;
+    if( command.prefix != prefix ) return;
     if ( commandMap[command.name] == null ) return;
-    
+
     commandMap[command.name](command);
     
 

--- a/commands/command-handler.js
+++ b/commands/command-handler.js
@@ -1,21 +1,19 @@
-const commandMap = require('./command-map');
-const {prefix} = require('../config'); 
-module.exports = async function(message){
-    if (message.author.bot) return;
-    if (message.channel.type === 'dm') return;
-    
-    const line = message.content.split(' ');
-    let command = {
-        "name": line[0].substring(1).toLowerCase(),
-        "prefix": line[0].substring(0,1),
-        "args": line.slice(1),
-        "message": message,
-    };
-    
-    if( command.prefix != prefix ) return;
-    if ( commandMap[command.name] == null ) return;
+const commandMap = require('./command-map')
+const { prefix } = require('../config')
+module.exports = async function (message) {
+  if (message.author.bot) return
+  if (message.channel.type === 'dm') return
 
-    commandMap[command.name](command);
-    
+  const line = message.content.split(' ')
+  const command = {
+    name: line[0].substring(1).toLowerCase(),
+    prefix: line[0].substring(0, 1),
+    args: line.slice(1),
+    message: message
+  }
 
+  if (command.prefix !== prefix) return
+  if (commandMap[command.name] == null) return
+
+  commandMap[command.name](command)
 }

--- a/commands/command-map.js
+++ b/commands/command-map.js
@@ -1,16 +1,16 @@
-const ping = require("./ping");
-const stats = require("./stats");
-const ban = require("./ban");
-const kick = require("./kick");
-const purge = require("./purge");
-const mute = require("./mute");
-const unmute = require("./unmute");
+const ping = require('./ping')
+const stats = require('./stats')
+const ban = require('./ban')
+const kick = require('./kick')
+const purge = require('./purge')
+const mute = require('./mute')
+const unmute = require('./unmute')
 module.exports = {
-    "ping": ping,
-    "stats": stats,
-    "kick": kick,
-    "ban": ban,
-    "purge": purge,
-    "mute": mute,
-    "unmute": unmute
+  ping: ping,
+  stats: stats,
+  kick: kick,
+  ban: ban,
+  purge: purge,
+  mute: mute,
+  unmute: unmute
 }

--- a/commands/command-map.js
+++ b/commands/command-map.js
@@ -1,4 +1,16 @@
 const ping = require("./ping");
-module.export = {
-    "ping": ping
+const stats = require("./stats");
+const ban = require("./ban");
+const kick = require("./kick");
+const purge = require("./purge");
+const mute = require("./mute");
+const unmute = require("./unmute");
+module.exports = {
+    "ping": ping,
+    "stats": stats,
+    "kick": kick,
+    "ban": ban,
+    "purge": purge,
+    "mute": mute,
+    "unmute": unmute
 }

--- a/commands/command-map.js
+++ b/commands/command-map.js
@@ -1,0 +1,4 @@
+const ping = require("./ping");
+module.export = {
+    "ping": ping
+}

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,0 +1,10 @@
+module.exports = async function(command){
+    if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
+        let {message, args} = command;
+        let guild = command.message.guild;
+        let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
+        
+        await member.kick(member).catch(console.error);
+        //add message whenever someone gets kicked to a logging channel
+    }
+}

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,10 +1,9 @@
-module.exports = async function(command){
-    if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
-        let {message, args} = command;
-        let guild = command.message.guild;
-        let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-        
-        await member.kick(member).catch(console.error);
-        //add message whenever someone gets kicked to a logging channel
-    }
+module.exports = async function (command) {
+  if (command.message.member.hasPermission('MANAGE_MESSAGES')) {
+    const { message, args } = command
+    const member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0])
+
+    await member.kick(member).catch(console.error)
+    // add message whenever someone gets kicked to a logging channel
+  }
 }

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -1,10 +1,9 @@
-const {mute_role} = require("../config");
+const { muteRole } = require('../config')
 
-module.exports = async function(command){
-    const {message,args} = command;
-    if (message.member.hasPermission('MANAGE_MESSAGES')) {
-              let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-              if (member && member.id !== message.author.id && member.highestRole.position < message.member.highestRole.position)
-                await member.addRole(message.guild.roles.get(mute_role));
-    }
+module.exports = async function (command) {
+  const { message, args } = command
+  if (message.member.hasPermission('MANAGE_MESSAGES')) {
+    const member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0])
+    if (member && member.id !== message.author.id && member.highestRole.position < message.member.highestRole.position) { await member.addRole(message.guild.roles.get(muteRole)) }
+  }
 }

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -1,0 +1,10 @@
+const {mute_role} = require("../config");
+
+module.exports = async function(command){
+    const {message,args} = command;
+    if (message.member.hasPermission('MANAGE_MESSAGES')) {
+              let member = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
+              if (member && member.id !== message.author.id && member.highestRole.position < message.member.highestRole.position)
+                await member.addRole(message.guild.roles.get(mute_role));
+    }
+}

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,3 +1,3 @@
-module.exports = async function(command){
-    await command.message.channel.send("pong");
+module.exports = async function (command) {
+  await command.message.channel.send('pong')
 }

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,0 +1,3 @@
+module.exports = async function(command){
+    await command.message.channel.send("pong");
+}

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -1,7 +1,8 @@
-module.exports = async function(command){
-    const num = parseInt(command.args[0], 10);
-    if (num) {
-      const fetchMsg = await command.message.channel.fetchMessages({ limit: num });
-      await command.message.channel.bulkDelete(fetchMsg).catch(e => message.reply(`Couldn't delete messages because of: ${e}`));
-    }
+module.exports = async function (command) {
+  const num = parseInt(command.args[0], 10)
+  const { message } = command
+  if (num) {
+    const fetchMsg = await command.message.channel.fetchMessages({ limit: num })
+    await command.message.channel.bulkDelete(fetchMsg).catch(e => message.reply(`Couldn't delete messages because of: ${e}`))
+  }
 }

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -1,0 +1,7 @@
+module.exports = async function(command){
+    const num = parseInt(command.args[0], 10);
+    if (num) {
+      const fetchMsg = await command.message.channel.fetchMessages({ limit: num });
+      await command.message.channel.bulkDelete(fetchMsg).catch(e => message.reply(`Couldn't delete messages because of: ${e}`));
+    }
+}

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -1,23 +1,23 @@
-const Discord = require("discord.js");
+const Discord = require('discord.js')
 
-module.exports = async function(command){
-    let guild = command.message.guild;
-    let online = guild.members.filter(m => m.presence.status === 'online');
-    let admins = online.filter(m => m.roles.has('619209554261049345'));
-    let dnd = guild.members.filter(m => m.presence.status === 'do not disturb');
-    let idle = guild.members.filter(m => m.presence.status === 'idle');
+module.exports = async function (command) {
+  const guild = command.message.guild
+  const online = guild.members.filter(m => m.presence.status === 'online')
+  const admins = online.filter(m => m.roles.has('619209554261049345'))
+  const dnd = guild.members.filter(m => m.presence.status === 'do not disturb')
+  const idle = guild.members.filter(m => m.presence.status === 'idle')
 
-    let embed = new Discord.RichEmbed()
-      .setDescription('Information')
-      .setColor('#15f153')
-      .setThumbnail(guild.iconURL)
-      .addField('Server Name', guild.name)
-      .addField('Created On', guild.createdAt)
-      .addField('Total Members', guild.memberCount)
-      .addField('Online', online.size)
-      .addField('Do Not Disturb', dnd.size)
-      .addField('Idle', idle.size)
-      .addField('Admins available', admins.size);
+  const embed = new Discord.RichEmbed()
+    .setDescription('Information')
+    .setColor('#15f153')
+    .setThumbnail(guild.iconURL)
+    .addField('Server Name', guild.name)
+    .addField('Created On', guild.createdAt)
+    .addField('Total Members', guild.memberCount)
+    .addField('Online', online.size)
+    .addField('Do Not Disturb', dnd.size)
+    .addField('Idle', idle.size)
+    .addField('Admins available', admins.size)
 
-    await command.message.channel.send(embed);
+  await command.message.channel.send(embed)
 }

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -1,0 +1,23 @@
+const Discord = require("discord.js");
+
+module.exports = async function(command){
+    let guild = command.message.guild;
+    let online = guild.members.filter(m => m.presence.status === 'online');
+    let admins = online.filter(m => m.roles.has('619209554261049345'));
+    let dnd = guild.members.filter(m => m.presence.status === 'do not disturb');
+    let idle = guild.members.filter(m => m.presence.status === 'idle');
+
+    let embed = new Discord.RichEmbed()
+      .setDescription('Information')
+      .setColor('#15f153')
+      .setThumbnail(guild.iconURL)
+      .addField('Server Name', guild.name)
+      .addField('Created On', guild.createdAt)
+      .addField('Total Members', guild.memberCount)
+      .addField('Online', online.size)
+      .addField('Do Not Disturb', dnd.size)
+      .addField('Idle', idle.size)
+      .addField('Admins available', admins.size);
+
+    await command.message.channel.send(embed);
+}

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -1,0 +1,8 @@
+const {muted_role} = require("../config");
+module.exports = async function(command){
+    const {message,args} = command;
+    if (message.member.hasPermission('MANAGE_MESSAGES')) {
+        let unYeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
+        if (unYeet) await unYeet.removeRole(message.guild.roles.get(muted_role));
+    }
+}

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -1,8 +1,8 @@
-const {muted_role} = require("../config");
-module.exports = async function(command){
-    const {message,args} = command;
-    if (message.member.hasPermission('MANAGE_MESSAGES')) {
-        let unYeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);
-        if (unYeet) await unYeet.removeRole(message.guild.roles.get(muted_role));
-    }
+const { mutedRole } = require('../config')
+module.exports = async function (command) {
+  const { message, args } = command
+  if (message.member.hasPermission('MANAGE_MESSAGES')) {
+    const unYeet = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0])
+    if (unYeet) await unYeet.removeRole(message.guild.roles.get(mutedRole))
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,18 @@
     "author": "lienne",
     "scripts": {
         "test": "nodemon bot.js",
-	"start": "node bot.js"
+        "start": "node bot.js"
     },
     "dependencies": {
         "discord.js": "^11.3.2"
     },
     "devDependencies": {
+        "eslint": "^6.3.0",
+        "eslint-config-standard": "^14.1.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-node": "^10.0.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^4.0.1",
         "nodemon": "^1.19.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,17 @@
 {
     "name": "lancelot",
     "version": "0.0.1",
-    "description": "Bot created with create-discord-bot CLI",
+    "description": "KnightHacks' Discord Bot",
     "main": "bot.js",
     "author": "lienne",
+    "scripts": {
+        "test": "nodemon bot.js",
+	"start": "node bot.js"
+    },
     "dependencies": {
         "discord.js": "^11.3.2"
+    },
+    "devDependencies": {
+        "nodemon": "^1.19.2"
     }
 }


### PR DESCRIPTION
- Restructured how the whole command protocol and future commands can be added so that the `bot.js` is not 500 lines long and debugging is easier.
- Created `npm test` and `npm start`. `npm test` uses nodemon which restarts the bot every time the codebase is saved. `npm start` is to start the whole thing properly.
- Edited `README.md` so that it redirects to KnightHacks discord.